### PR TITLE
Allow movement while menu is open

### DIFF
--- a/Client/Client.lua
+++ b/Client/Client.lua
@@ -1,13 +1,51 @@
-
-
-
 RegisterCommand('openemote', function()
     SetNuiFocus(true, true)
+
+    
+    SetNuiFocusKeepInput(true)
+
+
     SendNUIMessage({
         action = 'open'
     })   
+    Animaciones_isOpen = true
+
+    CreateThread(function()
+        while Animaciones_isOpen do
+            DisableDisplayControlActions()
+            Wait(1)
+        end
+    end)
+
 end)
 
+
+
+function DisableDisplayControlActions()
+
+    DisableControlAction(0, 1, true) -- disable mouse look
+    DisableControlAction(0, 2, true) -- disable mouse look
+    DisableControlAction(0, 3, true) -- disable mouse look
+    DisableControlAction(0, 4, true) -- disable mouse look
+    DisableControlAction(0, 5, true) -- disable mouse look
+    DisableControlAction(0, 6, true) -- disable mouse look
+    DisableControlAction(0, 263, true) -- disable melee
+    DisableControlAction(0, 264, true) -- disable melee
+    DisableControlAction(0, 257, true) -- disable melee
+    DisableControlAction(0, 140, true) -- disable melee
+    DisableControlAction(0, 141, true) -- disable melee
+    DisableControlAction(0, 142, true) -- disable melee
+    DisableControlAction(0, 143, true) -- disable melee
+    DisableControlAction(0, 177, true) -- disable escape
+    DisableControlAction(0, 200, true) -- disable escape
+    DisableControlAction(0, 202, true) -- disable escape
+    DisableControlAction(0, 322, true) -- disable escape
+    DisableControlAction(0, 245, true) -- disable chat
+    DisableControlAction(0, 37, true) -- disable TAB
+    DisableControlAction(0, 261, true) -- disable mouse wheel
+    DisableControlAction(0, 262, true) -- disable mouse wheel
+    HideHudComponentThisFrame(19)
+end
 
 RegisterKeyMapping('openemote', 'Open Roda Animations', 'keyboard', Config.OpenKey)
 
@@ -86,6 +124,7 @@ end)
 
 RegisterNUICallback("exit" , function(data, cb)
     SetNuiFocus(false, false)
+    Animaciones_isOpen = false
     SendNUIMessage({
         action = 'exit'
     })
@@ -98,6 +137,7 @@ RegisterNUICallback("executeemote" , function(data, cb)
     SendNUIMessage({
         action = 'exit'
     })
+    Animaciones_isOpen = false
     if data.type == 'walk' then 
         ExecuteCommand('walk '..data.emote)
     elseif data.type == 'emote' then 


### PR DESCRIPTION
Update to Client.lua to allow walking, jumping while having the animations menu open.

Blocks camera movements and prevents it from bumping while selecting an animation with the click